### PR TITLE
Add bower.json file for have this lib in bower 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,17 @@ The latest release (v0.2.1) includes custom header support but is larger than th
 
 ## Install
 
-Can be used via browserify:
+You can use npm or bower :
 
 ```
-npm install nanoajax
+npm install --save nanoajax
 ```
+
+```
+bower install --save nanoajax
+```
+
+Can be used via browserify:
 
 ```javascript
 var nanoajax = require('nanoajax')

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "nanoajax",
+  "main": "nanoajax.min.js",
+  "version": "0.2.4",
+  "homepage": "https://github.com/yanatan16/nanoajax",
+  "authors": [
+    "Jon Eise <jon@joneisen.me>"
+  ],
+  "description": "An ajax library you need a microscope to see.",
+  "keywords": [
+    "ajax",
+    "nano",
+    "javascript",
+    "cross-browser"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
As you say in one of your issues [Add to Bower](https://github.com/yanatan16/nanoajax/issues/8), I allowed myself to associate your repo has a bower.json file.

With that, and once the pull accepted , I will simply register your repository to make accessible it via bower.

The command will be : 

```
      bower register nanoajax https://github.com/yanatan16/nanoajax
```

But this command can be applied only if your repository have bower.json file. So please accept this version of your project for can I put your project on bower.io :)
