### PR TITLE
Add Typescript definition file

### DIFF
--- a/nanoajax.d.ts
+++ b/nanoajax.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for nanoajax v0.2.4
+// Project: https://github.com/yanatan16/nanoajax
+// Definitions by: Nathan Cahill <https://github.com/nathancahill/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module 'nanoajax' {
+    interface RequestParameters {
+        url: string;
+        headers?: { [key: string]: string; };
+        body?: string|FormData;
+        method?: string;
+        cors?: boolean;
+    }
+
+    interface Callback {
+        (statusCode: number, response: string, request: XMLHttpRequest): any
+    }
+
+    export function ajax(params: RequestParameters, callback: Callback): XMLHttpRequest
+}


### PR DESCRIPTION
I'm using nanoajax in a Typescript project, so I wrote a definition file based on your comments in the source. If you'd rather not have a ts definition in the project, feel free to ignore the PR (I also submitted to DefinitelyTyped: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/8312)
