### PR TITLE
Fix SYNTAX_ERR: DOM Exception 12

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,9 @@ exports.ajax = function (params, callback) {
   for (var i = 0, len = reqfields.length, field; i < len; i++) {
     field = reqfields[i]
     if (params[field] !== undefined)
-      req[field] = params[field]
+      try {
+        req[field] = params[field]
+      } catch (e) {}
   }
 
   for (var field in headers)


### PR DESCRIPTION
Fix SYNTAX_ERR: DOM Exception 12 on Android <4.2.2 default mobile browser when responsType is json.